### PR TITLE
added intro and notes for communication as pattern to be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 
 The Patient Corrections Implementation Guide provides a method for communicating a patient's request for corrections to their patient data, as well as a way for health care organizations to respond to those requests.
 
+Continuous build available https://build.fhir.org/ig/HL7/fhir-patient-correction/
+
+Patient Empowerment zulip chat stream https://chat.fhir.org/#narrow/stream/179262-patient-empowerment
+

--- a/input/pagecontent/StructureDefinition-patient-correction-communication-intro.md
+++ b/input/pagecontent/StructureDefinition-patient-correction-communication-intro.md
@@ -1,0 +1,10 @@
+Intro text for your profile
+
+## Header you would like to have
+
+Text where you explain how to use this profile
+
+### Sub headers
+
+More text
+

--- a/input/pagecontent/StructureDefinition-patient-correction-communication-intro.md
+++ b/input/pagecontent/StructureDefinition-patient-correction-communication-intro.md
@@ -1,10 +1,10 @@
 Intro text for your profile
 
-## Header you would like to have
+### Header you would like to have
 
 Text where you explain how to use this profile
 
-### Sub headers
+#### Sub headers
 
 More text
 

--- a/input/pagecontent/StructureDefinition-patient-correction-communication-notes.md
+++ b/input/pagecontent/StructureDefinition-patient-correction-communication-notes.md
@@ -1,0 +1,10 @@
+Notes text for your profile
+
+## Header you would like to have
+
+Text where you explain how to use this profile
+
+### Sub headers
+
+More text
+

--- a/input/pagecontent/StructureDefinition-patient-correction-communication-notes.md
+++ b/input/pagecontent/StructureDefinition-patient-correction-communication-notes.md
@@ -1,10 +1,10 @@
 Notes text for your profile
 
-## Header you would like to have
+### Header you would like to have
 
 Text where you explain how to use this profile
 
-### Sub headers
+#### Sub headers
 
 More text
 


### PR DESCRIPTION
This has the intro and notes pattern I mentioned. Note the two new markdown files. The root of the file is the same as the rendered resource and has "-intro" and "-notes" at the end of the filename.

also I updated the readme.md to point at the rendered version no the CI build